### PR TITLE
Avoid double Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ before_install:
   - gem update --system
   - gem install bundler
 cache: bundler
+branches:
+  only:
+    - master
 matrix:
   include:
   - rvm: 2.3.8


### PR DESCRIPTION
At the moment we build on both PRs and pushes which causes two builds
when you push to a branch with an open PR. In order to prevent this,
from now on it will only build for the master branch and PR branches.

https://github.com/travis-ci/travis-ci/issues/1147